### PR TITLE
Fix original path OSError on Windows machines

### DIFF
--- a/SavePatch.py
+++ b/SavePatch.py
@@ -50,6 +50,10 @@ def main():
 
     monitor.setMessage("Waiting for user input")
     orig_path   = str(currentProgram.getExecutablePath())
+    
+    if os.name == "nt":
+        orig_path = orig_path[1:]
+    
     output_path = str(askFile("Select output file name","Save changes"))
 
     if not os.path.isfile(output_path):


### PR DESCRIPTION
If the OS is Windows, remove leading `/` in `orig_path` (should start with `/` only on unix, windows' path starts with drive letter), preventing copying the original to destination only without doing any changes by fixing this error:
```
Traceback (most recent call last):
  File "C:\ghidra\Ghidra\Features\Python\ghidra_scripts\SavePatch.py", line 70, in <module>
    main()
  File "C:\ghidra\Ghidra\Features\Python\ghidra_scripts\SavePatch.py", line 56, in main
    shutil.copy(orig_path,output_path)
  File "C:\ghidra\Ghidra\Features\Python\data\jython-2.7.2\Lib\shutil.py", line 120, in copy
    copymode(src, dst)
  File "C:\ghidra\Ghidra\Features\Python\data\jython-2.7.2\Lib\shutil.py", line 89, in copymode
    st = os.stat(src)
OSError: [Errno 22] Invalid argument: '/C:/Users/d0gg3r/Documents/temp/exatlon_clear'
```
where source file is `C:\Users\d0gg3r\Documents\temp\exatlon_clear`.