### PR TITLE
Fix running on Windows

### DIFF
--- a/SavePatch.py
+++ b/SavePatch.py
@@ -52,7 +52,7 @@ def main():
     orig_path   = str(currentProgram.getExecutablePath())
     
     # workaround for https://github.com/NationalSecurityAgency/ghidra/pull/2220
-    if os.name == "nt" and orig_path[0] == "/":
+    if os.sep == "\\" and orig_path[0] == "/":
         orig_path = orig_path[1:]
     
     output_path = str(askFile("Select output file name","Save changes"))


### PR DESCRIPTION
When running inside Ghidra, `os.name` is `"java"`, so the check `if os.name == "nt"` in the check for an errant leading `/` didn't work, and `SavePatch.py` would simply error out on Windows. With this, `os.sep == "\\"` is checked instead – a characteristic only Windows has among the platforms Ghidra supports – and the script thus runs on Windows!

This fix will work whether `os.name` is `"nt"` (as seems to be the case for the creator of #2?) or `"java"`.